### PR TITLE
oh-my-codex 프로젝트 설정 적용

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,8 @@
 # oh-my-codex top-level settings (must be before any [table])
-notify = ["node", "/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/notify-hook.js"]
+notify = ["node", "/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/scripts/notify-hook.js"]
 model_reasoning_effort = "medium"
 developer_instructions = "You have oh-my-codex installed. AGENTS.md is your orchestration brain and the main orchestration surface. Use skill/keyword routing like $name plus spawned role-specialized subagents for specialized work. Codex native subagents are available via .codex/agents and may be used for independent parallel subtasks within a single session or team pane. Skills are loaded from installed SKILL.md files under .codex/skills, not from native agent TOMLs. Use workflow skills via $name when explicitly invoked or clearly routed by AGENTS.md. Treat installed prompts as narrower internal execution surfaces under AGENTS.md authority, even when user-facing docs prefer $name keywords."
+
 model = "gpt-5.5"
 # oh-my-codex seeded behavioral defaults (uninstall removes unchanged defaults)
 model_context_window = 250000
@@ -28,35 +29,35 @@ max_depth = 2
 # OMX State Management MCP Server
 [mcp_servers.omx_state]
 command = "node"
-args = ["/opt/homebrew/lib/node_modules/oh-my-codex/dist/mcp/state-server.js"]
+args = ["/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/mcp/state-server.js"]
 enabled = true
 startup_timeout_sec = 5
 
 # OMX Project Memory MCP Server
 [mcp_servers.omx_memory]
 command = "node"
-args = ["/opt/homebrew/lib/node_modules/oh-my-codex/dist/mcp/memory-server.js"]
+args = ["/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/mcp/memory-server.js"]
 enabled = true
 startup_timeout_sec = 5
 
 # OMX Code Intelligence MCP Server (LSP diagnostics, AST search)
 [mcp_servers.omx_code_intel]
 command = "node"
-args = ["/opt/homebrew/lib/node_modules/oh-my-codex/dist/mcp/code-intel-server.js"]
+args = ["/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/mcp/code-intel-server.js"]
 enabled = true
 startup_timeout_sec = 10
 
 # OMX Trace MCP Server (agent flow timeline & statistics)
 [mcp_servers.omx_trace]
 command = "node"
-args = ["/opt/homebrew/lib/node_modules/oh-my-codex/dist/mcp/trace-server.js"]
+args = ["/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/mcp/trace-server.js"]
 enabled = true
 startup_timeout_sec = 5
 
 # OMX Wiki MCP Server (persistent project knowledge base)
 [mcp_servers.omx_wiki]
 command = "node"
-args = ["/opt/homebrew/lib/node_modules/oh-my-codex/dist/mcp/wiki-server.js"]
+args = ["/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/mcp/wiki-server.js"]
 enabled = true
 startup_timeout_sec = 5
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js\""
+            "command": "node \"/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js\""
+            "command": "node \"/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js\""
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js\""
+            "command": "node \"/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js\""
           }
         ]
       }
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js\""
+            "command": "node \"/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js\""
           }
         ]
       }
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js\"",
+            "command": "node \"/home/hefxpzwk/.nvm/versions/node/v22.22.2/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js\"",
             "timeout": 30
           }
         ]

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 !.codex/prompts/**
 !.codex/config.toml
 !.codex/hooks.json
+.omx/


### PR DESCRIPTION
## 작업 내용
- `oh-my-codex@0.15.0`을 전역 설치했습니다.
- `omx setup --force --verbose --scope project`로 프로젝트 범위 설정을 갱신했습니다.
- `.codex/config.toml`과 `.codex/hooks.json`의 이전 `/opt/homebrew` 경로를 현재 nvm 전역 설치 경로로 갱신했습니다.
- `.omx/` 런타임 상태 파일이 저장소에 섞이지 않도록 `.gitignore`에 추가했습니다.

## 검증
- `omx --version`
- `omx doctor` 결과: 13 passed, 0 warnings, 0 failed

Closes #5