### PR TITLE
feat (#21) : tmux 실분할 멀티 에이전트 데모 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,25 @@ npm test
 - Consensus Board에서 어떤 의견이 충돌했고 왜 그 방향으로 확정됐는지 바로 볼 수 있습니다.
 - Final Decision 패널에서 최종 코드 미리보기까지 한 화면에서 확인할 수 있습니다.
 - `--no-delay` 옵션으로 발표 리허설과 테스트를 빠르게 돌릴 수 있습니다.
+
+
+## 실제 tmux 분할 데모
+
+### 실행
+```bash
+npm run tmux-demo
+```
+
+또는
+```bash
+node ./src/cli.js --tmux "결제 API 만들어줘"
+```
+
+### 패널 구성
+- 좌측: Architect / Red Team / Blue Team
+- 우측 상단: Consensus Board
+- 우측 하단: Final Decision
+
+### 참고
+- 세션만 만들고 바로 붙지 않으려면 `--no-attach`
+- 세션 이름을 바꾸려면 `--session-name my-demo`

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "node ./src/cli.js",
     "demo": "node ./src/cli.js",
+    "tmux-demo": "node ./src/cli.js --tmux \"보안이 강화된 login API 만들어줘\"",
     "test": "node ./test/cli.test.js"
   },
   "engines": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { buildDemoScenario } from './demo-data.js';
 
 const color = {
@@ -10,8 +13,15 @@ const color = {
   yellow: '\u001b[33m',
   red: '\u001b[31m',
   green: '\u001b[32m',
-  magenta: '\u001b[35m',
-  gray: '\u001b[90m'
+  magenta: '\u001b[35m'
+};
+
+const ROLE_META = {
+  architect: { tone: 'cyan', title: 'Architect', subtitle: '구조 설계 / API 초안 제안' },
+  red: { tone: 'red', title: 'Red Team', subtitle: '공격 시나리오 / 취약점 지적' },
+  blue: { tone: 'blue', title: 'Blue Team', subtitle: '방어 전략 / 패치 제안' },
+  consensus: { tone: 'yellow', title: 'Consensus Board', subtitle: '의견 충돌 / 조율 / 최종 판정' },
+  final: { tone: 'green', title: 'Final Decision', subtitle: '확정안 / 최종 코드 요약' }
 };
 
 function paint(text, tone) {
@@ -20,208 +30,242 @@ function paint(text, tone) {
 
 function parseArgs(argv) {
   const args = argv.slice(2);
+  const promptParts = [];
+  let role = null;
+  let sessionName = 'multiverse-sec-demo';
+  let promptBase64 = null;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--role') {
+      role = args[index + 1] ?? null;
+      index += 1;
+    } else if (arg === '--session-name') {
+      sessionName = args[index + 1] ?? sessionName;
+      index += 1;
+    } else if (arg === '--prompt-b64') {
+      promptBase64 = args[index + 1] ?? null;
+      index += 1;
+    } else if (!arg.startsWith('--')) {
+      promptParts.push(arg);
+    }
+  }
+
   return {
     help: args.includes('--help') || args.includes('-h'),
     noDelay: args.includes('--no-delay'),
-    prompt: args.filter((arg) => !arg.startsWith('--')).join(' ').trim()
+    tmux: args.includes('--tmux'),
+    noAttach: args.includes('--no-attach'),
+    role,
+    sessionName,
+    promptBase64,
+    prompt: promptParts.join(' ').trim()
   };
-}
-
-function visibleWidth(text) {
-  return text.replace(/\u001b\[[0-9;]*m/g, '').length;
-}
-
-function pad(text, width) {
-  const gap = Math.max(0, width - visibleWidth(text));
-  return text + ' '.repeat(gap);
-}
-
-function wrapText(text, width) {
-  const rawLines = String(text).split('\n');
-  const result = [];
-  for (const rawLine of rawLines) {
-    const words = rawLine.split(' ');
-    let current = '';
-    for (const word of words) {
-      const next = current ? `${current} ${word}` : word;
-      if (visibleWidth(next) <= width) {
-        current = next;
-      } else {
-        if (current) result.push(current);
-        if (visibleWidth(word) <= width) {
-          current = word;
-        } else {
-          let chunk = '';
-          for (const char of word) {
-            if (visibleWidth(chunk + char) > width) {
-              result.push(chunk);
-              chunk = char;
-            } else {
-              chunk += char;
-            }
-          }
-          current = chunk;
-        }
-      }
-    }
-    result.push(current || '');
-  }
-  return result;
-}
-
-function makeBox({ title, subtitle, tone = 'cyan', lines, width }) {
-  const innerWidth = width - 2;
-  const rendered = [];
-  rendered.push(`┌${'─'.repeat(innerWidth)}┐`);
-  rendered.push(`│${pad(paint(title, tone), innerWidth)}│`);
-  rendered.push(`│${pad(paint(subtitle, 'dim'), innerWidth)}│`);
-  rendered.push(`├${'─'.repeat(innerWidth)}┤`);
-  for (const line of lines) {
-    for (const wrapped of wrapText(line, innerWidth)) {
-      rendered.push(`│${pad(wrapped, innerWidth)}│`);
-    }
-  }
-  rendered.push(`└${'─'.repeat(innerWidth)}┘`);
-  return rendered;
-}
-
-function mergeColumns(leftLines, rightLines, gap = 2) {
-  const leftWidth = Math.max(...leftLines.map((line) => visibleWidth(line)), 0);
-  const rows = Math.max(leftLines.length, rightLines.length);
-  const merged = [];
-  for (let index = 0; index < rows; index += 1) {
-    const left = leftLines[index] ?? '';
-    const right = rightLines[index] ?? '';
-    merged.push(`${pad(left, leftWidth)}${' '.repeat(gap)}${right}`.trimEnd());
-  }
-  return merged;
-}
-
-function stackBoxes(boxes) {
-  return boxes.flatMap((box, index) => index === 0 ? box : ['', ...box]);
 }
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function maybePause(noDelay, ms = 220) {
+async function maybePause(noDelay, ms = 280) {
   if (!noDelay) {
     await sleep(ms);
   }
 }
 
-function buildAgentLines(scenario) {
-  const architect = scenario.proposals.find((item) => item.agent === 'Architect');
-  const red = scenario.proposals.find((item) => item.agent === 'Red Team');
-  const blue = scenario.proposals.find((item) => item.agent === 'Blue Team');
-
-  return {
-    architect: [
-      `현재 작업: ${architect.idea}`,
-      `설계 방향: ${architect.detail}`,
-      '산출물: API 구조/레이어 분리 제안'
-    ],
-    red: [
-      `현재 작업: ${red.idea}`,
-      `공격 포인트: ${red.detail}`,
-      `주요 반박: ${scenario.debate[0].message}`
-    ],
-    blue: [
-      `현재 작업: ${blue.idea}`,
-      `방어 전략: ${blue.detail}`,
-      `대응 방안: ${scenario.debate[1].message}`
-    ]
-  };
+function decodePrompt(prompt, promptBase64) {
+  if (promptBase64) {
+    return Buffer.from(promptBase64, 'base64').toString('utf8');
+  }
+  return prompt || '보안이 강화된 login API 만들어줘';
 }
 
-function renderSplitDashboard(scenario) {
-  const totalWidth = Math.max(112, Number(process.stdout.columns) || 112);
-  const columnGap = 2;
-  const leftWidth = 56;
-  const rightWidth = totalWidth - leftWidth - columnGap;
-  const agentLines = buildAgentLines(scenario);
-
-  const leftColumn = stackBoxes([
-    makeBox({
-      title: '좌상단 | Architect 패널',
-      subtitle: '역할: 구조 설계 / API 초안 제안',
-      tone: 'cyan',
-      lines: agentLines.architect,
-      width: leftWidth
-    }),
-    makeBox({
-      title: '좌중단 | Red Team 패널',
-      subtitle: '역할: 공격 시나리오 / 취약점 지적',
-      tone: 'red',
-      lines: agentLines.red,
-      width: leftWidth
-    }),
-    makeBox({
-      title: '좌하단 | Blue Team 패널',
-      subtitle: '역할: 방어 전략 / 패치 제안',
-      tone: 'blue',
-      lines: agentLines.blue,
-      width: leftWidth
-    })
-  ]);
-
-  const rightColumn = stackBoxes([
-    makeBox({
-      title: '우측 상단 | Consensus Board',
-      subtitle: '역할: AI 의견 충돌 / 조율 / 최종 판정',
-      tone: 'yellow',
-      lines: scenario.debate.map((turn, index) => `${index + 1}. ${turn.from} → ${turn.to}: ${turn.message}`),
-      width: rightWidth
-    }),
-    makeBox({
-      title: '우측 하단 | Final Decision',
-      subtitle: '역할: 확정된 방향과 최종 코드 요약',
-      tone: 'green',
-      lines: [
-        `확정안: ${scenario.decision.winner}`,
-        `합의 흐름: ${scenario.decision.summary}`,
-        '선정 이유:',
-        ...scenario.decision.reason.map((reason) => `- ${reason}`),
-        '최종 코드 미리보기:',
-        '  --- final-code.js ---',
-        ...scenario.finalCode.split('\n').map((line) => `  ${line}`)
-      ],
-      width: rightWidth
-    })
-  ]);
-
-  return mergeColumns(leftColumn, rightColumn, columnGap);
+function printPaneHeader(roleKey, prompt) {
+  const role = ROLE_META[roleKey];
+  const line = '─'.repeat(72);
+  console.log(paint(line, role.tone));
+  console.log(paint(`${role.title} 패널`, role.tone));
+  console.log(paint(`역할: ${role.subtitle}`, 'dim'));
+  console.log(paint(`Prompt: ${prompt}`, 'dim'));
+  console.log(paint(line, role.tone));
 }
 
-function renderLegend() {
-  return [
-    paint('레이아웃 안내', 'bold'),
-    `${paint('좌측', 'cyan')} 각 AI가 자기 역할별로 작업하는 패널`,
-    `${paint('우측', 'yellow')} AI 의견 조율 / 판정 / 최종 결과를 모아보는 패널`
+async function renderRolePane(roleKey, scenario, noDelay) {
+  printPaneHeader(roleKey, scenario.prompt);
+
+  if (roleKey === 'architect') {
+    const architect = scenario.proposals.find((item) => item.agent === 'Architect');
+    console.log(`현재 작업: ${architect.idea}`);
+    await maybePause(noDelay);
+    console.log(`설계 방향: ${architect.detail}`);
+    await maybePause(noDelay);
+    console.log('산출물: API 구조/레이어 분리 제안');
+    await maybePause(noDelay);
+    console.log(paint('상태: 구조 제안 완료, Red Team 검토 대기', 'cyan'));
+    return;
+  }
+
+  if (roleKey === 'red') {
+    const red = scenario.proposals.find((item) => item.agent === 'Red Team');
+    console.log(`현재 작업: ${red.idea}`);
+    await maybePause(noDelay);
+    console.log(`공격 포인트: ${red.detail}`);
+    await maybePause(noDelay);
+    console.log(`주요 반박: ${scenario.debate[0].message}`);
+    await maybePause(noDelay);
+    console.log(paint('상태: 취약점 분석 완료, Blue Team 대응 확인 중', 'red'));
+    return;
+  }
+
+  if (roleKey === 'blue') {
+    const blue = scenario.proposals.find((item) => item.agent === 'Blue Team');
+    console.log(`현재 작업: ${blue.idea}`);
+    await maybePause(noDelay);
+    console.log(`방어 전략: ${blue.detail}`);
+    await maybePause(noDelay);
+    console.log(`대응 방안: ${scenario.debate[1].message}`);
+    await maybePause(noDelay);
+    console.log(paint('상태: 방어안 제시 완료, Judge 판정 대기', 'blue'));
+    return;
+  }
+
+  if (roleKey === 'consensus') {
+    for (const [index, turn] of scenario.debate.entries()) {
+      console.log(`${index + 1}. ${turn.from} → ${turn.to}`);
+      console.log(`   ${turn.message}`);
+      await maybePause(noDelay, 420);
+    }
+    console.log();
+    console.log(paint(`[Judge] ${scenario.decision.winner}로 확정`, 'yellow'));
+    console.log(`합의 흐름: ${scenario.decision.summary}`);
+    return;
+  }
+
+  if (roleKey === 'final') {
+    console.log(`확정안: ${scenario.decision.winner}`);
+    await maybePause(noDelay);
+    console.log('선정 이유:');
+    for (const reason of scenario.decision.reason) {
+      console.log(`- ${reason}`);
+      await maybePause(noDelay, 220);
+    }
+    console.log();
+    console.log('--- final-code.js ---');
+    console.log(scenario.finalCode);
+  }
+}
+
+function shellEscape(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function runTmux(args, options = {}) {
+  const result = spawnSync('tmux', args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    ...options
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || `tmux command failed: ${args.join(' ')}`);
+  }
+
+  return result;
+}
+
+function runTmuxAndRead(args) {
+  return runTmux(args).stdout.trim();
+}
+
+function buildPaneCommand(roleKey, prompt, noDelay) {
+  const scriptPath = fileURLToPath(import.meta.url);
+  const promptBase64 = Buffer.from(prompt, 'utf8').toString('base64');
+  const parts = [
+    shellEscape(process.execPath),
+    shellEscape(scriptPath),
+    '--role',
+    shellEscape(roleKey),
+    '--prompt-b64',
+    shellEscape(promptBase64)
   ];
+
+  if (noDelay) {
+    parts.push('--no-delay');
+  }
+
+  parts.push(';', 'printf', shellEscape('\n\n[done] pane completed. Press Ctrl-b d to detach.\n'), ';', 'exec', process.env.SHELL || '/bin/zsh');
+  return parts.join(' ');
+}
+
+function launchTmuxDashboard({ sessionName, prompt, noDelay, noAttach }) {
+  const existing = spawnSync('tmux', ['has-session', '-t', sessionName], { encoding: 'utf8' });
+  if (existing.status === 0) {
+    throw new Error(`tmux session '${sessionName}' 이(가) 이미 존재합니다. 다른 이름을 사용하거나 세션을 종료하세요.`);
+  }
+
+  const architectPane = runTmuxAndRead(['new-session', '-d', '-P', '-F', '#{pane_id}', '-s', sessionName, '-n', 'agents', buildPaneCommand('architect', prompt, noDelay)]);
+  const consensusPane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-h', '-t', architectPane, buildPaneCommand('consensus', prompt, noDelay)]);
+  const redPane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-v', '-t', architectPane, buildPaneCommand('red', prompt, noDelay)]);
+  const bluePane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-v', '-t', architectPane, buildPaneCommand('blue', prompt, noDelay)]);
+  const finalPane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-v', '-t', consensusPane, buildPaneCommand('final', prompt, noDelay)]);
+  runTmux(['select-layout', '-t', `${sessionName}:0`, 'tiled']);
+  runTmux(['select-pane', '-t', architectPane, '-T', 'Architect']);
+  runTmux(['select-pane', '-t', consensusPane, '-T', 'Consensus']);
+  runTmux(['select-pane', '-t', redPane, '-T', 'Red Team']);
+  runTmux(['select-pane', '-t', bluePane, '-T', 'Blue Team']);
+  runTmux(['select-pane', '-t', finalPane, '-T', 'Final Decision']);
+  runTmux(['set-option', '-t', sessionName, 'mouse', 'on']);
+
+  console.log(paint(`tmux 세션 '${sessionName}' 생성 완료`, 'green'));
+  console.log(`붙기: tmux attach -t ${sessionName}`);
+  console.log('패널 구성: 좌측 Architect/Red/Blue, 우측 Consensus/Final');
+
+  if (!noAttach) {
+    const attach = spawnSync('tmux', ['attach-session', '-t', sessionName], { stdio: 'inherit' });
+    if (attach.status !== 0) {
+      throw new Error('tmux attach-session 실행에 실패했습니다.');
+    }
+  }
+}
+
+function printHelp() {
+  console.log('사용법:');
+  console.log('  multiverse-sec "요청 내용" [--no-delay]');
+  console.log('  multiverse-sec --tmux "요청 내용" [--session-name 이름] [--no-delay]');
+  console.log('');
+  console.log('옵션:');
+  console.log('  --tmux         실제 tmux pane 분할 데모를 실행합니다.');
+  console.log('  --no-attach    tmux 세션 생성만 하고 바로 붙지 않습니다.');
+  console.log('  --session-name 생성할 tmux 세션 이름을 지정합니다.');
+  console.log('  --no-delay     패널 출력 지연을 제거합니다.');
 }
 
 export async function runCli(argv = process.argv) {
-  const { help, noDelay, prompt } = parseArgs(argv);
+  const { help, noDelay, prompt, tmux, noAttach, sessionName, role, promptBase64 } = parseArgs(argv);
+  const decodedPrompt = decodePrompt(prompt, promptBase64);
+  const scenario = buildDemoScenario(decodedPrompt);
 
   if (help) {
-    console.log('사용법: multiverse-sec "요청 내용" [--no-delay]');
-    console.log('예시: multiverse-sec "보안이 강화된 login API 만들어줘"');
-    console.log('설명: 좌측은 AI 작업 패널, 우측은 합의/최종 결정 패널을 표시합니다.');
+    printHelp();
     return 0;
   }
 
-  const scenario = buildDemoScenario(prompt || '보안이 강화된 login API 만들어줘');
-  await maybePause(noDelay, 120);
+  if (role) {
+    await renderRolePane(role, scenario, noDelay);
+    return 0;
+  }
+
+  if (tmux) {
+    launchTmuxDashboard({ sessionName, prompt: decodedPrompt, noDelay, noAttach });
+    return 0;
+  }
 
   console.log(paint('Multiverse Secure Demo', 'magenta'));
   console.log(paint('분할형 멀티 에이전트 대시보드', 'bold'));
   console.log(paint(`Prompt: ${scenario.prompt}`, 'dim'));
   console.log();
-  console.log(renderLegend().join('\n'));
-  console.log();
-  console.log(renderSplitDashboard(scenario).join('\n'));
+  console.log(paint('실제 pane 분할이 필요하면 --tmux 옵션으로 실행하세요.', 'yellow'));
+  console.log(paint(`예시: node ${path.relative(process.cwd(), fileURLToPath(import.meta.url))} --tmux "${scenario.prompt}"`, 'dim'));
 
   return 0;
 }
@@ -232,7 +276,7 @@ if (isDirectRun) {
     process.exitCode = code;
   }).catch((error) => {
     console.error(paint('CLI 실행 중 오류가 발생했습니다.', 'red'));
-    console.error(error);
+    console.error(error.message || error);
     process.exitCode = 1;
   });
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,27 +1,47 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 
-const demoResult = spawnSync('node', ['./src/cli.js', '회원가입 API 만들어줘', '--no-delay'], {
-  encoding: 'utf8'
-});
-
-assert.equal(demoResult.status, 0, demoResult.stderr);
-assert.match(demoResult.stdout, /분할형 멀티 에이전트 대시보드/);
-assert.match(demoResult.stdout, /좌상단 \| Architect 패널/);
-assert.match(demoResult.stdout, /좌중단 \| Red Team 패널/);
-assert.match(demoResult.stdout, /좌하단 \| Blue Team 패널/);
-assert.match(demoResult.stdout, /우측 상단 \| Consensus Board/);
-assert.match(demoResult.stdout, /우측 하단 \| Final Decision/);
-assert.match(demoResult.stdout, /AI 의견 충돌 \/ 조율 \/ 최종 판정/);
-assert.match(demoResult.stdout, /final-code\.js/);
-assert.match(demoResult.stdout, /issueAccessToken/);
-
 const helpResult = spawnSync('node', ['./src/cli.js', '--help'], {
   encoding: 'utf8'
 });
-
 assert.equal(helpResult.status, 0, helpResult.stderr);
-assert.match(helpResult.stdout, /사용법:/);
-assert.match(helpResult.stdout, /좌측은 AI 작업 패널, 우측은 합의\/최종 결정 패널/);
+assert.match(helpResult.stdout, /--tmux/);
+assert.match(helpResult.stdout, /--no-attach/);
 
-console.log('CLI split dashboard smoke test passed');
+const architectResult = spawnSync('node', ['./src/cli.js', '--role', 'architect', '--prompt-b64', Buffer.from('회원가입 API 만들어줘').toString('base64'), '--no-delay'], {
+  encoding: 'utf8'
+});
+assert.equal(architectResult.status, 0, architectResult.stderr);
+assert.match(architectResult.stdout, /Architect 패널/);
+assert.match(architectResult.stdout, /구조 설계/);
+
+const sessionName = `multiverse-sec-test-${Date.now()}`;
+const tmuxResult = spawnSync('node', ['./src/cli.js', '--tmux', '결제 API 만들어줘', '--session-name', sessionName, '--no-delay', '--no-attach'], {
+  encoding: 'utf8'
+});
+assert.equal(tmuxResult.status, 0, tmuxResult.stderr);
+assert.match(tmuxResult.stdout, new RegExp(sessionName));
+
+const listResult = spawnSync('tmux', ['list-panes', '-t', `${sessionName}:0`, '-F', '#{pane_id} #{pane_title}'], {
+  encoding: 'utf8'
+});
+assert.equal(listResult.status, 0, listResult.stderr);
+assert.match(listResult.stdout, /Architect/);
+assert.match(listResult.stdout, /Consensus/);
+assert.match(listResult.stdout, /Red Team/);
+assert.match(listResult.stdout, /Blue Team/);
+assert.match(listResult.stdout, /Final Decision/);
+
+const consensusLine = listResult.stdout.split('\n').find((line) => line.includes('Consensus'));
+assert.ok(consensusLine, 'Consensus pane not found');
+const consensusPaneId = consensusLine.split(' ')[0];
+
+const captureResult = spawnSync('tmux', ['capture-pane', '-p', '-S', '-200', '-t', consensusPaneId], {
+  encoding: 'utf8'
+});
+assert.equal(captureResult.status, 0, captureResult.stderr);
+assert.match(captureResult.stdout, /Consensus Board 패널/);
+assert.match(captureResult.stdout, /Judge/);
+
+spawnSync('tmux', ['kill-session', '-t', sessionName], { encoding: 'utf8' });
+console.log('CLI tmux split smoke test passed');


### PR DESCRIPTION
## 요약
- tmux 실제 pane 분할 실행 모드 추가
- Architect / Red / Blue / Consensus / Final pane 구성
- tmux 실행 검증 테스트 및 문서 추가

## 테스트
- npm test
- node ./src/cli.js --tmux "결제 API 만들어줘" --session-name verify-multiverse-64023 --no-delay --no-attach

Closes #21