### PR TITLE
feat (#23) : 저장형 로그인 인증 플로우 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,24 @@ node ./src/cli.js --tmux "결제 API 만들어줘"
 ### 참고
 - 세션만 만들고 바로 붙지 않으려면 `--no-attach`
 - 세션 이름을 바꾸려면 `--session-name my-demo`
+
+
+## 로그인 저장형 인증
+
+### 개요
+- 최초 1회만 provider를 연결하면 다음 실행부터 자동 재사용합니다.
+- 민감한 API 키는 일반 설정 파일이 아니라 안전 저장소에 보관합니다.
+- macOS에서는 기본적으로 Keychain을 사용합니다.
+
+### 명령어
+```bash
+node ./src/cli.js login
+node ./src/cli.js providers
+node ./src/cli.js logout --provider openai
+```
+
+### 동작 방식
+- `login`: OpenAI / Claude / Gemini 중 하나를 선택해 키를 저장
+- `providers`: 현재 연결 상태와 기본 provider 확인
+- `logout`: 특정 provider 연결 제거
+- 일반 실행 / tmux 실행: 저장된 기본 provider를 자동 재사용

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,277 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+export const PROVIDERS = [
+  { id: 'openai', label: 'OpenAI', credentialLabel: 'OpenAI API Key' },
+  { id: 'claude', label: 'Claude', credentialLabel: 'Claude API Key' },
+  { id: 'gemini', label: 'Gemini', credentialLabel: 'Gemini API Key' }
+];
+
+const SERVICE_NAME = 'multiverse-sec';
+
+function getConfigRoot() {
+  if (process.env.MULTIVERSE_SEC_CONFIG_DIR) {
+    return process.env.MULTIVERSE_SEC_CONFIG_DIR;
+  }
+  return path.join(os.homedir(), '.multiverse-sec');
+}
+
+function ensureConfigRoot() {
+  const root = getConfigRoot();
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  return root;
+}
+
+function getConfigPath() {
+  return path.join(ensureConfigRoot(), 'config.json');
+}
+
+function getBackendMode() {
+  if (process.env.MULTIVERSE_SEC_TEST_SECRET_BACKEND) {
+    return process.env.MULTIVERSE_SEC_TEST_SECRET_BACKEND;
+  }
+  if (process.platform === 'darwin') {
+    return 'keychain';
+  }
+  return 'file';
+}
+
+function getSecretPath(provider) {
+  return path.join(ensureConfigRoot(), `${provider}.secret`);
+}
+
+function readJson(filePath, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + '\n', { mode: 0o600 });
+}
+
+function keychainAccount(provider) {
+  return `${SERVICE_NAME}:${provider}`;
+}
+
+function storeInKeychain(provider, secret) {
+  const account = keychainAccount(provider);
+  spawnSync('security', ['delete-generic-password', '-s', SERVICE_NAME, '-a', account], { encoding: 'utf8' });
+  const result = spawnSync('security', ['add-generic-password', '-U', '-s', SERVICE_NAME, '-a', account, '-w', secret], {
+    encoding: 'utf8'
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || 'Keychain 저장에 실패했습니다.');
+  }
+}
+
+function readFromKeychain(provider) {
+  const account = keychainAccount(provider);
+  const result = spawnSync('security', ['find-generic-password', '-s', SERVICE_NAME, '-a', account, '-w'], {
+    encoding: 'utf8'
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+  return result.stdout.trim();
+}
+
+function deleteFromKeychain(provider) {
+  const account = keychainAccount(provider);
+  spawnSync('security', ['delete-generic-password', '-s', SERVICE_NAME, '-a', account], { encoding: 'utf8' });
+}
+
+function storeSecret(provider, secret) {
+  const backend = getBackendMode();
+  if (backend === 'keychain') {
+    storeInKeychain(provider, secret);
+    return 'macOS Keychain';
+  }
+  fs.writeFileSync(getSecretPath(provider), secret, { mode: 0o600 });
+  return '로컬 보호 파일';
+}
+
+function readSecret(provider) {
+  const backend = getBackendMode();
+  if (backend === 'keychain') {
+    return readFromKeychain(provider);
+  }
+  try {
+    return fs.readFileSync(getSecretPath(provider), 'utf8').trim();
+  } catch {
+    return null;
+  }
+}
+
+function deleteSecret(provider) {
+  const backend = getBackendMode();
+  if (backend === 'keychain') {
+    deleteFromKeychain(provider);
+    return;
+  }
+  try {
+    fs.unlinkSync(getSecretPath(provider));
+  } catch {}
+}
+
+export function loadAuthConfig() {
+  return readJson(getConfigPath(), {
+    defaultProvider: null,
+    providers: {}
+  });
+}
+
+export function saveAuthConfig(config) {
+  writeJson(getConfigPath(), config);
+}
+
+export function getProviderMeta(provider) {
+  return PROVIDERS.find((item) => item.id === provider) ?? null;
+}
+
+export function listProviderStates() {
+  const config = loadAuthConfig();
+  return PROVIDERS.map((provider) => ({
+    ...provider,
+    configured: Boolean(config.providers?.[provider.id]?.configured),
+    isDefault: config.defaultProvider === provider.id
+  }));
+}
+
+export function getStoredCredential(provider) {
+  return readSecret(provider);
+}
+
+export function setProviderCredential(provider, secret, makeDefault = false) {
+  const config = loadAuthConfig();
+  const storageLabel = storeSecret(provider, secret);
+  config.providers[provider] = {
+    configured: true,
+    storage: storageLabel,
+    updatedAt: new Date().toISOString()
+  };
+  if (makeDefault || !config.defaultProvider) {
+    config.defaultProvider = provider;
+  }
+  saveAuthConfig(config);
+  return { storageLabel, config };
+}
+
+export function removeProviderCredential(provider) {
+  const config = loadAuthConfig();
+  deleteSecret(provider);
+  delete config.providers[provider];
+  if (config.defaultProvider === provider) {
+    const nextProvider = Object.keys(config.providers)[0] ?? null;
+    config.defaultProvider = nextProvider;
+  }
+  saveAuthConfig(config);
+}
+
+export function resolveDefaultProvider() {
+  const config = loadAuthConfig();
+  if (config.defaultProvider && getStoredCredential(config.defaultProvider)) {
+    return config.defaultProvider;
+  }
+  for (const provider of PROVIDERS) {
+    if (config.providers?.[provider.id]?.configured && getStoredCredential(provider.id)) {
+      config.defaultProvider = provider.id;
+      saveAuthConfig(config);
+      return provider.id;
+    }
+  }
+  return null;
+}
+
+export async function ask(question) {
+  const rl = readline.createInterface({ input, output });
+  try {
+    const answer = await rl.question(question);
+    return answer.trim();
+  } finally {
+    rl.close();
+  }
+}
+
+export async function askHidden(question) {
+  if (!input.isTTY) {
+    throw new Error('보안 입력은 TTY 환경에서만 가능합니다.');
+  }
+  output.write(question);
+  input.setRawMode?.(true);
+  input.resume();
+  input.setEncoding('utf8');
+
+  return await new Promise((resolve) => {
+    let value = '';
+    const onData = (chunk) => {
+      const char = String(chunk);
+      if (char === '\r' || char === '\n') {
+        output.write('\n');
+        input.setRawMode?.(false);
+        input.pause();
+        input.removeListener('data', onData);
+        resolve(value.trim());
+        return;
+      }
+      if (char === '\u0003') {
+        output.write('^C\n');
+        process.exit(1);
+      }
+      if (char === '\u007f') {
+        value = value.slice(0, -1);
+        return;
+      }
+      value += char;
+    };
+    input.on('data', onData);
+  });
+}
+
+export async function runInteractiveLogin(preselectedProvider = null, presetSecret = null) {
+  const provider = preselectedProvider ?? await chooseProvider();
+  const meta = getProviderMeta(provider);
+  if (!meta) {
+    throw new Error('지원하지 않는 provider입니다.');
+  }
+  const secret = presetSecret ?? await askHidden(`${meta.credentialLabel}를 입력하세요: `);
+  if (!secret) {
+    throw new Error('비어 있는 키는 저장할 수 없습니다.');
+  }
+  const defaultAnswer = await ask('기본 provider로 설정할까요? (Y/n): ');
+  const makeDefault = defaultAnswer === '' || /^y(es)?$/i.test(defaultAnswer);
+  const { storageLabel } = setProviderCredential(provider, secret, makeDefault);
+  return { provider, storageLabel, makeDefault };
+}
+
+export async function chooseProvider() {
+  console.log('연결할 AI 제공자를 선택하세요.');
+  for (const [index, provider] of PROVIDERS.entries()) {
+    console.log(`${index + 1}. ${provider.label}`);
+  }
+  const answer = await ask('번호를 입력하세요: ');
+  const index = Number(answer) - 1;
+  const provider = PROVIDERS[index];
+  if (!provider) {
+    throw new Error('올바른 provider 번호를 입력해주세요.');
+  }
+  return provider.id;
+}
+
+export async function ensureAuthenticatedOnboarding() {
+  const provider = resolveDefaultProvider();
+  if (provider) {
+    return provider;
+  }
+
+  console.log('초기 연결이 필요합니다. 한번만 설정하면 다음부터 자동으로 재사용됩니다.');
+  const result = await runInteractiveLogin();
+  console.log(`${getProviderMeta(result.provider).label} 연결 완료 · 저장 위치: ${result.storageLabel}`);
+  return result.provider;
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,16 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { buildDemoScenario } from './demo-data.js';
+import {
+  ensureAuthenticatedOnboarding,
+  getProviderMeta,
+  getStoredCredential,
+  listProviderStates,
+  loadAuthConfig,
+  removeProviderCredential,
+  resolveDefaultProvider,
+  runInteractiveLogin
+} from './auth.js';
 
 const color = {
   reset: '\u001b[0m',
@@ -34,10 +44,15 @@ function parseArgs(argv) {
   let role = null;
   let sessionName = 'multiverse-sec-demo';
   let promptBase64 = null;
+  let provider = null;
+  let command = null;
+  let apiKey = null;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (arg === '--role') {
+    if (arg === 'login' || arg === 'providers' || arg === 'logout') {
+      command = arg;
+    } else if (arg === '--role') {
       role = args[index + 1] ?? null;
       index += 1;
     } else if (arg === '--session-name') {
@@ -45,6 +60,12 @@ function parseArgs(argv) {
       index += 1;
     } else if (arg === '--prompt-b64') {
       promptBase64 = args[index + 1] ?? null;
+      index += 1;
+    } else if (arg === '--provider') {
+      provider = args[index + 1] ?? null;
+      index += 1;
+    } else if (arg === '--api-key') {
+      apiKey = args[index + 1] ?? null;
       index += 1;
     } else if (!arg.startsWith('--')) {
       promptParts.push(arg);
@@ -59,7 +80,10 @@ function parseArgs(argv) {
     role,
     sessionName,
     promptBase64,
-    prompt: promptParts.join(' ').trim()
+    prompt: promptParts.join(' ').trim(),
+    provider,
+    command,
+    apiKey
   };
 }
 
@@ -80,18 +104,19 @@ function decodePrompt(prompt, promptBase64) {
   return prompt || '보안이 강화된 login API 만들어줘';
 }
 
-function printPaneHeader(roleKey, prompt) {
+function printPaneHeader(roleKey, prompt, providerLabel) {
   const role = ROLE_META[roleKey];
   const line = '─'.repeat(72);
   console.log(paint(line, role.tone));
   console.log(paint(`${role.title} 패널`, role.tone));
   console.log(paint(`역할: ${role.subtitle}`, 'dim'));
+  console.log(paint(`Provider: ${providerLabel}`, 'dim'));
   console.log(paint(`Prompt: ${prompt}`, 'dim'));
   console.log(paint(line, role.tone));
 }
 
-async function renderRolePane(roleKey, scenario, noDelay) {
-  printPaneHeader(roleKey, scenario.prompt);
+async function renderRolePane(roleKey, scenario, noDelay, providerLabel) {
+  printPaneHeader(roleKey, scenario.prompt, providerLabel);
 
   if (roleKey === 'architect') {
     const architect = scenario.proposals.find((item) => item.agent === 'Architect');
@@ -177,7 +202,7 @@ function runTmuxAndRead(args) {
   return runTmux(args).stdout.trim();
 }
 
-function buildPaneCommand(roleKey, prompt, noDelay) {
+function buildPaneCommand(roleKey, prompt, noDelay, provider) {
   const scriptPath = fileURLToPath(import.meta.url);
   const promptBase64 = Buffer.from(prompt, 'utf8').toString('base64');
   const parts = [
@@ -186,7 +211,9 @@ function buildPaneCommand(roleKey, prompt, noDelay) {
     '--role',
     shellEscape(roleKey),
     '--prompt-b64',
-    shellEscape(promptBase64)
+    shellEscape(promptBase64),
+    '--provider',
+    shellEscape(provider)
   ];
 
   if (noDelay) {
@@ -197,17 +224,17 @@ function buildPaneCommand(roleKey, prompt, noDelay) {
   return parts.join(' ');
 }
 
-function launchTmuxDashboard({ sessionName, prompt, noDelay, noAttach }) {
+function launchTmuxDashboard({ sessionName, prompt, noDelay, noAttach, provider }) {
   const existing = spawnSync('tmux', ['has-session', '-t', sessionName], { encoding: 'utf8' });
   if (existing.status === 0) {
     throw new Error(`tmux session '${sessionName}' 이(가) 이미 존재합니다. 다른 이름을 사용하거나 세션을 종료하세요.`);
   }
 
-  const architectPane = runTmuxAndRead(['new-session', '-d', '-P', '-F', '#{pane_id}', '-s', sessionName, '-n', 'agents', buildPaneCommand('architect', prompt, noDelay)]);
-  const consensusPane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-h', '-t', architectPane, buildPaneCommand('consensus', prompt, noDelay)]);
-  const redPane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-v', '-t', architectPane, buildPaneCommand('red', prompt, noDelay)]);
-  const bluePane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-v', '-t', architectPane, buildPaneCommand('blue', prompt, noDelay)]);
-  const finalPane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-v', '-t', consensusPane, buildPaneCommand('final', prompt, noDelay)]);
+  const architectPane = runTmuxAndRead(['new-session', '-d', '-P', '-F', '#{pane_id}', '-s', sessionName, '-n', 'agents', buildPaneCommand('architect', prompt, noDelay, provider)]);
+  const consensusPane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-h', '-t', architectPane, buildPaneCommand('consensus', prompt, noDelay, provider)]);
+  const redPane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-v', '-t', architectPane, buildPaneCommand('red', prompt, noDelay, provider)]);
+  const bluePane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-v', '-t', architectPane, buildPaneCommand('blue', prompt, noDelay, provider)]);
+  const finalPane = runTmuxAndRead(['split-window', '-P', '-F', '#{pane_id}', '-v', '-t', consensusPane, buildPaneCommand('final', prompt, noDelay, provider)]);
   runTmux(['select-layout', '-t', `${sessionName}:0`, 'tiled']);
   runTmux(['select-pane', '-t', architectPane, '-T', 'Architect']);
   runTmux(['select-pane', '-t', consensusPane, '-T', 'Consensus']);
@@ -217,6 +244,7 @@ function launchTmuxDashboard({ sessionName, prompt, noDelay, noAttach }) {
   runTmux(['set-option', '-t', sessionName, 'mouse', 'on']);
 
   console.log(paint(`tmux 세션 '${sessionName}' 생성 완료`, 'green'));
+  console.log(`Provider: ${getProviderMeta(provider)?.label ?? provider}`);
   console.log(`붙기: tmux attach -t ${sessionName}`);
   console.log('패널 구성: 좌측 Architect/Red/Blue, 우측 Consensus/Final');
 
@@ -230,38 +258,91 @@ function launchTmuxDashboard({ sessionName, prompt, noDelay, noAttach }) {
 
 function printHelp() {
   console.log('사용법:');
-  console.log('  multiverse-sec "요청 내용" [--no-delay]');
+  console.log('  multiverse-sec login [--provider openai|claude|gemini]');
+  console.log('  multiverse-sec providers');
+  console.log('  multiverse-sec logout --provider openai|claude|gemini');
   console.log('  multiverse-sec --tmux "요청 내용" [--session-name 이름] [--no-delay]');
   console.log('');
   console.log('옵션:');
   console.log('  --tmux         실제 tmux pane 분할 데모를 실행합니다.');
   console.log('  --no-attach    tmux 세션 생성만 하고 바로 붙지 않습니다.');
   console.log('  --session-name 생성할 tmux 세션 이름을 지정합니다.');
+  console.log('  --provider     provider를 명시합니다.');
+  console.log('  --api-key      비대화형 login에 사용할 API 키를 전달합니다.');
   console.log('  --no-delay     패널 출력 지연을 제거합니다.');
 }
 
+function printProviders() {
+  const states = listProviderStates();
+  console.log(paint('연결된 AI 제공자 상태', 'bold'));
+  for (const state of states) {
+    const status = state.configured ? paint('연결됨', 'green') : paint('미연결', 'yellow');
+    const defaultMark = state.isDefault ? paint(' (기본)', 'cyan') : '';
+    console.log(`- ${state.label}: ${status}${defaultMark}`);
+  }
+}
+
+async function runLogin(provider, apiKey) {
+  const result = await runInteractiveLogin(provider ?? null, apiKey ?? null);
+  console.log(paint(`${getProviderMeta(result.provider).label} 연결 완료`, 'green'));
+  console.log(`저장 위치: ${result.storageLabel}`);
+  if (result.makeDefault) {
+    console.log('기본 provider로 설정했습니다.');
+  }
+}
+
+function runLogout(provider) {
+  if (!provider) {
+    throw new Error('logout에는 --provider 가 필요합니다.');
+  }
+  if (!getStoredCredential(provider)) {
+    throw new Error('해당 provider는 현재 연결되어 있지 않습니다.');
+  }
+  removeProviderCredential(provider);
+  console.log(paint(`${getProviderMeta(provider)?.label ?? provider} 연결을 제거했습니다.`, 'green'));
+}
+
 export async function runCli(argv = process.argv) {
-  const { help, noDelay, prompt, tmux, noAttach, sessionName, role, promptBase64 } = parseArgs(argv);
+  const { help, noDelay, prompt, tmux, noAttach, sessionName, role, promptBase64, provider, command, apiKey } = parseArgs(argv);
   const decodedPrompt = decodePrompt(prompt, promptBase64);
-  const scenario = buildDemoScenario(decodedPrompt);
 
   if (help) {
     printHelp();
     return 0;
   }
 
+  if (command === 'login') {
+    await runLogin(provider, apiKey);
+    return 0;
+  }
+
+  if (command === 'providers') {
+    printProviders();
+    return 0;
+  }
+
+  if (command === 'logout') {
+    runLogout(provider);
+    return 0;
+  }
+
+  const effectiveProvider = role ? (provider ?? resolveDefaultProvider() ?? 'unconfigured') : await ensureAuthenticatedOnboarding();
+  const providerLabel = getProviderMeta(effectiveProvider)?.label ?? effectiveProvider;
+  const scenario = buildDemoScenario(decodedPrompt);
+
   if (role) {
-    await renderRolePane(role, scenario, noDelay);
+    await renderRolePane(role, scenario, noDelay, providerLabel);
     return 0;
   }
 
   if (tmux) {
-    launchTmuxDashboard({ sessionName, prompt: decodedPrompt, noDelay, noAttach });
+    launchTmuxDashboard({ sessionName, prompt: decodedPrompt, noDelay, noAttach, provider: effectiveProvider });
     return 0;
   }
 
   console.log(paint('Multiverse Secure Demo', 'magenta'));
   console.log(paint('분할형 멀티 에이전트 대시보드', 'bold'));
+  console.log(paint(`Provider: ${providerLabel}`, 'dim'));
   console.log(paint(`Prompt: ${scenario.prompt}`, 'dim'));
   console.log();
   console.log(paint('실제 pane 분할이 필요하면 --tmux 옵션으로 실행하세요.', 'yellow'));

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,25 +1,58 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'multiverse-sec-test-'));
+const env = {
+  ...process.env,
+  MULTIVERSE_SEC_CONFIG_DIR: tempDir,
+  MULTIVERSE_SEC_TEST_SECRET_BACKEND: 'file'
+};
+
 const helpResult = spawnSync('node', ['./src/cli.js', '--help'], {
-  encoding: 'utf8'
+  encoding: 'utf8',
+  env
 });
 assert.equal(helpResult.status, 0, helpResult.stderr);
+assert.match(helpResult.stdout, /login/);
+assert.match(helpResult.stdout, /providers/);
+assert.match(helpResult.stdout, /logout/);
 assert.match(helpResult.stdout, /--tmux/);
-assert.match(helpResult.stdout, /--no-attach/);
 
-const architectResult = spawnSync('node', ['./src/cli.js', '--role', 'architect', '--prompt-b64', Buffer.from('회원가입 API 만들어줘').toString('base64'), '--no-delay'], {
-  encoding: 'utf8'
+const loginResult = spawnSync('node', ['./src/cli.js', 'login', '--provider', 'openai', '--api-key', 'test-openai-key'], {
+  encoding: 'utf8',
+  env,
+  input: 'Y\n'
+});
+assert.equal(loginResult.status, 0, loginResult.stderr);
+assert.match(loginResult.stdout, /OpenAI 연결 완료/);
+
+const providersResult = spawnSync('node', ['./src/cli.js', 'providers'], {
+  encoding: 'utf8',
+  env
+});
+assert.equal(providersResult.status, 0, providersResult.stderr);
+assert.match(providersResult.stdout, /OpenAI/);
+assert.match(providersResult.stdout, /연결됨/);
+assert.match(providersResult.stdout, /기본/);
+
+const architectResult = spawnSync('node', ['./src/cli.js', '--role', 'architect', '--provider', 'openai', '--prompt-b64', Buffer.from('회원가입 API 만들어줘').toString('base64'), '--no-delay'], {
+  encoding: 'utf8',
+  env
 });
 assert.equal(architectResult.status, 0, architectResult.stderr);
+assert.match(architectResult.stdout, /Provider: OpenAI/);
 assert.match(architectResult.stdout, /Architect 패널/);
-assert.match(architectResult.stdout, /구조 설계/);
 
 const sessionName = `multiverse-sec-test-${Date.now()}`;
 const tmuxResult = spawnSync('node', ['./src/cli.js', '--tmux', '결제 API 만들어줘', '--session-name', sessionName, '--no-delay', '--no-attach'], {
-  encoding: 'utf8'
+  encoding: 'utf8',
+  env
 });
 assert.equal(tmuxResult.status, 0, tmuxResult.stderr);
+assert.match(tmuxResult.stdout, /Provider: OpenAI/);
 assert.match(tmuxResult.stdout, new RegExp(sessionName));
 
 const listResult = spawnSync('tmux', ['list-panes', '-t', `${sessionName}:0`, '-F', '#{pane_id} #{pane_title}'], {
@@ -40,8 +73,17 @@ const captureResult = spawnSync('tmux', ['capture-pane', '-p', '-S', '-200', '-t
   encoding: 'utf8'
 });
 assert.equal(captureResult.status, 0, captureResult.stderr);
+assert.match(captureResult.stdout, /Provider: OpenAI/);
 assert.match(captureResult.stdout, /Consensus Board 패널/);
 assert.match(captureResult.stdout, /Judge/);
 
 spawnSync('tmux', ['kill-session', '-t', sessionName], { encoding: 'utf8' });
-console.log('CLI tmux split smoke test passed');
+
+const logoutResult = spawnSync('node', ['./src/cli.js', 'logout', '--provider', 'openai'], {
+  encoding: 'utf8',
+  env
+});
+assert.equal(logoutResult.status, 0, logoutResult.stderr);
+assert.match(logoutResult.stdout, /연결을 제거했습니다/);
+
+console.log('CLI auth and tmux smoke test passed');


### PR DESCRIPTION
## 요약
- 1회 로그인 후 credential 자동 재사용 플로우 추가
- login / providers / logout 명령 추가
- 첫 실행 온보딩과 tmux 실행 연동 추가

## 테스트
- npm test
- temp config dir 기반 login/providers/tmux 검증

Closes #23