### PR TITLE
feat (#27) : 단축 실행과 슬래시 명령 별칭 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,28 @@ node ./src/cli.js providers
 ```bash
 node ./src/cli.js unassign --assign-role final
 ```
+
+
+## 단축 실행과 슬래시 명령
+
+### 실행 파일처럼 사용
+한 번만 아래를 실행하면 이후 `node ./src/cli.js` 없이 바로 실행할 수 있습니다.
+```bash
+npm link
+multiverse-sec /mode
+```
+
+### 슬래시 명령 예시
+```bash
+multiverse-sec /mode
+multiverse-sec /login openai
+multiverse-sec /providers
+multiverse-sec /use openai
+multiverse-sec /assign architect claude
+multiverse-sec /assign red gemini
+multiverse-sec /tmux "주문 API 만들어줘"
+```
+
+### 참고
+- `/oauth` 는 `/login` 별칭입니다.
+- 실제로는 provider별 인증 방식이 다르므로 공통 OAuth 자체를 의미하지는 않습니다.

--- a/src/cli.js
+++ b/src/cli.js
@@ -31,13 +31,44 @@ const ROLE_META = {
 };
 function paint(text, tone) { return `${color[tone] ?? ''}${text}${color.reset}`; }
 
+function normalizeSlashCommand(command) {
+  const aliases = {
+    '/mode': 'mode',
+    '/login': 'login',
+    '/oauth': 'login',
+    '/providers': 'providers',
+    '/use': 'use',
+    '/assign': 'assign',
+    '/unassign': 'unassign',
+    '/logout': 'logout',
+    '/tmux': 'tmux'
+  };
+  return aliases[command] ?? command;
+}
+
 function parseArgs(argv) {
   const args = argv.slice(2);
   const promptParts = [];
   let role = null, sessionName = 'multiverse-sec-demo', promptBase64 = null, provider = null, command = null, apiKey = null, assignRole = null;
+  let slashArgs = [];
+
+  if (args[0]?.startsWith('/')) {
+    command = normalizeSlashCommand(args[0]);
+    slashArgs = args.slice(1);
+    if (command === 'use') provider = slashArgs[0] ?? null;
+    if (command === 'assign') { assignRole = slashArgs[0] ?? null; provider = slashArgs[1] ?? null; }
+    if (command === 'unassign') assignRole = slashArgs[0] ?? null;
+    if (command === 'logout') provider = slashArgs[0] ?? null;
+    if (command === 'login' && slashArgs[0] && !slashArgs[0].startsWith('--')) provider = slashArgs[0];
+    if (command === 'tmux') promptParts.push(...slashArgs.filter((arg) => !arg.startsWith('--')));
+  }
+
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (['login', 'providers', 'logout', 'use', 'assign', 'unassign'].includes(arg)) {
+    if (arg.startsWith('/')) {
+      continue;
+    }
+    if (['login', 'providers', 'logout', 'use', 'assign', 'unassign', 'mode'].includes(arg) && !command) {
       command = arg;
     } else if (arg === '--role') { role = args[index + 1] ?? null; index += 1;
     } else if (arg === '--assign-role') { assignRole = args[index + 1] ?? null; index += 1;
@@ -47,7 +78,7 @@ function parseArgs(argv) {
     } else if (arg === '--api-key') { apiKey = args[index + 1] ?? null; index += 1;
     } else if (!arg.startsWith('--')) { promptParts.push(arg); }
   }
-  return { help: args.includes('--help') || args.includes('-h'), noDelay: args.includes('--no-delay'), tmux: args.includes('--tmux'), noAttach: args.includes('--no-attach'), role, assignRole, sessionName, promptBase64, prompt: promptParts.join(' ').trim(), provider, command, apiKey };
+  return { help: args.includes('--help') || args.includes('-h'), noDelay: args.includes('--no-delay'), tmux: args.includes('--tmux') || command === 'tmux', noAttach: args.includes('--no-attach'), role, assignRole, sessionName, promptBase64, prompt: promptParts.join(' ').trim(), provider, command, apiKey };
 }
 
 function sleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
@@ -150,6 +181,20 @@ function launchTmuxDashboard({ sessionName, prompt, noDelay, noAttach }) {
   }
 }
 
+function printModeGuide() {
+  console.log(paint('Multiverse Secure 모드 안내', 'bold'));
+  console.log('- /login [provider]     : provider 연결을 시작합니다.');
+  console.log('- /oauth [provider]     : /login 별칭입니다.');
+  console.log('- /providers            : 연결된 provider와 역할 매핑을 보여줍니다.');
+  console.log('- /use <provider>       : 기본 provider를 변경합니다.');
+  console.log('- /assign <role> <provider>   : 역할별 provider를 할당합니다.');
+  console.log('- /unassign <role>      : 역할별 provider 할당을 제거합니다.');
+  console.log('- /logout <provider>    : provider 연결을 제거합니다.');
+  console.log('- /tmux <prompt>        : tmux 실분할 데모를 실행합니다.');
+  console.log('');
+  console.log('역할 목록: architect, red, blue, consensus, final');
+}
+
 function printHelp() {
   console.log('사용법:');
   console.log('  multiverse-sec login [--provider openai|claude|gemini]');
@@ -159,6 +204,9 @@ function printHelp() {
   console.log('  multiverse-sec unassign --assign-role architect|red|blue|consensus|final');
   console.log('  multiverse-sec logout --provider openai|claude|gemini');
   console.log('  multiverse-sec --tmux "요청 내용" [--session-name 이름] [--no-delay]');
+  console.log('  multiverse-sec /mode');
+  console.log('  multiverse-sec /login [provider]');
+  console.log('  multiverse-sec /assign <role> <provider>');
   console.log('');
   console.log('옵션:');
   console.log('  --tmux         실제 tmux pane 분할 데모를 실행합니다.');
@@ -202,6 +250,7 @@ export async function runCli(argv = process.argv) {
   const { help, noDelay, prompt, tmux, noAttach, sessionName, role, promptBase64, provider, command, apiKey, assignRole } = parseArgs(argv);
   const decodedPrompt = decodePrompt(prompt, promptBase64);
   if (help) { printHelp(); return 0; }
+  if (command === 'mode') { printModeGuide(); return 0; }
   if (command === 'login') { await runLogin(provider, apiKey); return 0; }
   if (command === 'providers') { printProviders(); return 0; }
   if (command === 'use') { runUse(provider); return 0; }
@@ -217,7 +266,7 @@ export async function runCli(argv = process.argv) {
   console.log(paint(`기본 Provider: ${providerLabel(effectiveProvider)}`, 'dim'));
   console.log(paint(`Prompt: ${scenario.prompt}`, 'dim'));
   console.log();
-  console.log(paint('실제 pane 분할이 필요하면 --tmux 옵션으로 실행하세요.', 'yellow'));
+  console.log(paint('실제 pane 분할이 필요하면 --tmux 옵션 또는 /tmux 를 사용하세요.', 'yellow'));
   console.log(paint(`예시: node ${path.relative(process.cwd(), fileURLToPath(import.meta.url))} --tmux "${scenario.prompt}"`, 'dim'));
   return 0;
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -13,6 +13,11 @@ let result = run(['--help']);
 assert.equal(result.status, 0, result.stderr);
 assert.match(result.stdout, /assign/);
 assert.match(result.stdout, /use/);
+result = run(['/mode']);
+assert.equal(result.status, 0, result.stderr);
+assert.match(result.stdout, /모드 안내/);
+assert.match(result.stdout, /\/oauth/);
+
 
 result = run(['login', '--provider', 'openai', '--api-key', 'test-openai-key'], 'Y\n');
 assert.equal(result.status, 0, result.stderr);
@@ -26,18 +31,18 @@ result = run(['login', '--provider', 'gemini', '--api-key', 'test-gemini-key'], 
 assert.equal(result.status, 0, result.stderr);
 assert.match(result.stdout, /Gemini 연결 완료/);
 
-result = run(['use', '--provider', 'openai']);
+result = run(['/use', 'openai']);
 assert.equal(result.status, 0, result.stderr);
 
-result = run(['assign', '--assign-role', 'architect', '--provider', 'claude']);
+result = run(['/assign', 'architect', 'claude']);
 assert.equal(result.status, 0, result.stderr);
-result = run(['assign', '--assign-role', 'red', '--provider', 'gemini']);
+result = run(['/assign', 'red', 'gemini']);
 assert.equal(result.status, 0, result.stderr);
-result = run(['assign', '--assign-role', 'blue', '--provider', 'openai']);
+result = run(['/assign', 'blue', 'openai']);
 assert.equal(result.status, 0, result.stderr);
-result = run(['assign', '--assign-role', 'consensus', '--provider', 'claude']);
+result = run(['/assign', 'consensus', 'claude']);
 assert.equal(result.status, 0, result.stderr);
-result = run(['assign', '--assign-role', 'final', '--provider', 'gemini']);
+result = run(['/assign', 'final', 'gemini']);
 assert.equal(result.status, 0, result.stderr);
 
 result = run(['providers']);
@@ -77,9 +82,13 @@ assert.match(capture.stdout, /Provider: Gemini/);
 
 spawnSync('tmux', ['kill-session', '-t', sessionName], { encoding: 'utf8' });
 
-result = run(['unassign', '--assign-role', 'final']);
+result = run(['/unassign', 'final']);
 assert.equal(result.status, 0, result.stderr);
-result = run(['logout', '--provider', 'gemini']);
+result = run(['/logout', 'gemini']);
 assert.equal(result.status, 0, result.stderr);
 
 console.log('CLI multi-provider and tmux smoke test passed');
+
+result = run(['/providers']);
+assert.equal(result.status, 0, result.stderr);
+assert.match(result.stdout, /역할별 provider 매핑/);


### PR DESCRIPTION
## 요약
- /mode, /login, /providers, /assign 등 슬래시 명령 별칭 추가
- /oauth 를 /login 별칭으로 지원
- npm link 기반 실행 가이드 추가

## 테스트
- npm test

Closes #27