### PR TITLE
fix (#29) : npm link 실행 시 메인 진입 감지 수정

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -271,7 +272,7 @@ export async function runCli(argv = process.argv) {
   return 0;
 }
 
-const isDirectRun = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+const isDirectRun = process.argv[1] && fs.realpathSync.native(fileURLToPath(import.meta.url)) === fs.realpathSync.native(path.resolve(process.argv[1]));
 if (isDirectRun) {
   runCli().then((code) => { process.exitCode = code; }).catch((error) => {
     console.error(paint('CLI 실행 중 오류가 발생했습니다.', 'red'));


### PR DESCRIPTION
## 요약
- npm link symlink 실행에서 메인 진입 감지 수정
- multiverse-sec 링크 실행 정상화

## 테스트
- npm test
- multiverse-sec --help
- multiverse-sec /mode

Closes #29